### PR TITLE
Remove hlint on release workflow.

### DIFF
--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -65,21 +65,3 @@ jobs:
         with:
           files: |
             built-with-cabal
-
-  hlint:
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          persist-credentials: false
-
-      - name: Set up HLint
-        uses: haskell/actions/hlint-setup@745062a754c3c4b70b87cb93937ad443096cc94d # tag=v1
-
-      - name: Run HLint
-        uses: haskell/actions/hlint-run@745062a754c3c4b70b87cb93937ad443096cc94d # tag=v1
-        with:
-          path: .
-          fail-on: warning


### PR DESCRIPTION
Since we test in CI on every push, this is not needed.

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>